### PR TITLE
Change to 1-base for exporter and page (not zero base)

### DIFF
--- a/includes/wppr-list-tables.php
+++ b/includes/wppr-list-tables.php
@@ -392,14 +392,11 @@ class WP_Personal_Data_Export_Requests_Table extends WP_List_Table {
 								method: 'post'
 							} ).done( function( response ) {
 								var responseData = response.data;
-								for ( var dataIndex = 0; dataIndex < responseData.data.length; dataIndex++ ) {
-									console.log( responseData.data[ dataIndex ].name, responseData.data[ dataIndex ].value );
-								}
 								if ( ! responseData.done ) {
 									setTimeout( do_next_export( exporterIndex, pageIndex + 1 ) );
 								} else {
-									if ( exporterIndex < exporterNames.length - 1 ) {
-										setTimeout( do_next_export( exporterIndex + 1, 0 ) );
+									if ( exporterIndex < exporterNames.length ) {
+										setTimeout( do_next_export( exporterIndex + 1, 1 ) );
 									} else {
 										console.log( responseData );
 										on_exports_done_success( responseData.url );
@@ -412,7 +409,7 @@ class WP_Personal_Data_Export_Requests_Table extends WP_List_Table {
 
 						// And now, let's begin
 						set_row_busy();
-						do_next_export( 0, 0 );
+						do_next_export( 1, 1 );
 					} )
 				} );
 			} ( jQuery ) );


### PR DESCRIPTION
Fixes #12 

To test:

First, set up the test environment ( assuming wordpress-svn working copy in `~/sites/localhost/wordpress-svn`) by doing the following:

```# Revert all changes
cd ~/sites/localhost/wordpress-svn
svn revert -R .
svn up

# Apply latest patch from https://core.trac.wordpress.org/ticket/43443
# This adds the latest version of the email confirmation code
cd src
patch -p0 < 43443.4.diff

cd ~/sites/localhost/wordpress-svn/src/wp-content/plugins

# Clone the temporary plugin if you haven’t already
git clone git@github.com:allendav/wp-privacy-requests.git

# Get this branch
cd wp-privacy-requests
git checkout fix/12-one-based
```

And then, do the following:

- Navigate to wp-admin > Tools > Personal Data Requests
- Select Personal Data Export if needed
- Enter an email address of a user with comments on the site
- Hit Send request
- Note the request should now appear in the table
- Hover over the email address in the table, then scroll down and click on Download Personal Data
- Open the Javascript Web Console
- Observe that export completes successfully and that you see the comment data in the web console